### PR TITLE
Added basic Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.7-alpine
+
+
+WORKDIR /usr/src/app
+COPY requirements.txt .
+RUN apk add --no-cache build-base;\
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" > /etc/apk/repositories ;\
+    echo "http://dl-cdn.alpinelinux.org/alpine/edge/main/" >> /etc/apk/repositories ;\
+    apk add --no-cache geos-dev geos libxml2 libspatialite;\
+    pip install -r requirements.txt;\
+    pip install gunicorn;\
+    apk del geos-dev build-base;\
+    apk add --no-cache libc-dev binutils; 
+ENV SPATIALITE_LIBRARY_PATH=/usr/lib/mod_spatialite.so.7
+
+
+COPY . .
+
+RUN python db_setup.py
+CMD gunicorn -b 0.0.0.0 -w 4 foodapi:app
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.event import listens_for
@@ -12,7 +14,7 @@ db = SQLAlchemy(app)
 @listens_for(db.engine, "connect")
 def load_spacialite(dbapi_conn, connection_record):
     dbapi_conn.enable_load_extension(True)
-    dbapi_conn.load_extension('/usr/lib/x86_64-linux-gnu/mod_spatialite.so')
+    dbapi_conn.load_extension(os.getenv('SPATIALITE_LIBRARY_PATH','/usr/lib/x86_64-linux-gnu/mod_spatialite.so'))
     print(db.app)
 db.engine.execute(select([func.InitSpatialMetaData(1)]))
 

--- a/db_setup.py
+++ b/db_setup.py
@@ -1,11 +1,12 @@
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen
+import os
 
 DB_NAME = 'gis.db'
 
 def load_spatialite(dbapi_conn, connection_record):
     dbapi_conn.enable_load_extension(True)
-    dbapi_conn.load_extension('/usr/lib/x86_64-linux-gnu/mod_spatialite.so')
+    dbapi_conn.load_extension(os.getenv('SPATIALITE_LIBRARY_PATH','/usr/lib/x86_64-linux-gnu/mod_spatialite.so'))
 
 import os
 if DB_NAME in os.listdir(os.getcwd()):


### PR DESCRIPTION
It's not the best docker configuration ever (image ends up 157 megs), but that's mainly shapely's fault, as it wants quite a few sets of c headers at runtime. It can probably be pared down later.

Other change is just to allow the PATH for spatialite library to be configurable.